### PR TITLE
Removed Pages from the navbar entries

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,7 +7,9 @@
   <div class="nav-scroller py-1 mb-2">
     <nav class="nav d-flex justify-content-center">
       {% for collection in site.collections %}
-      <a class="p-3 text-uppercase text-muted small" href="{{ collection.label | prepend: "/" | prepend: site.baseurl | prepend: site.url}}">{{ collection.label | capitalize }}</a>
+        {% if collection.label != 'posts' %}
+          <a class="p-3 text-uppercase text-muted small" href="{{ collection.label | prepend: "/" | prepend: site.baseurl | prepend: site.url}}">{{ collection.label | capitalize }}</a>
+        {% endif %}
       {% endfor %}
     </nav>
   </div>


### PR DESCRIPTION
There's no pages.md to handle the posts collection causing a 404 when someone clicks on https://alvaroduran.com/Onassis/posts

Pages is already excluded from _includes/index/categories.html, so I used this method for consistency.